### PR TITLE
Add a fix for the fill bug

### DIFF
--- a/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/east.mcfunction
+++ b/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_block_compressors:relocate/place_down_check
+# @s = command block placed by gm4_block_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_block_compressors:relocate/place_down_check
+# @s = command block placed by gm4_block_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/north.mcfunction
+++ b/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_block_compressors:relocate/place_down_check
+# @s = command block placed by gm4_block_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/south.mcfunction
+++ b/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_block_compressors:relocate/place_down_check
+# @s = command block placed by gm4_block_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/west.mcfunction
+++ b/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_block_compressors:relocate/place_down_check
+# @s = command block placed by gm4_block_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down_check.mcfunction
+++ b/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_block_compressors:relocate/replace_head

--- a/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/replace_head.mcfunction
+++ b/gm4_block_compressors/data/gm4_block_compressors/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_block_compressors:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_block_compressors:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-131091160,1198343456,-1997665138,1557892169]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_block_compressors:relocate/replace_head

--- a/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/east.mcfunction
+++ b/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_custom_crafters:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_custom_crafters:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/north.mcfunction
+++ b/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_custom_crafters:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/south.mcfunction
+++ b/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_custom_crafters:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/west.mcfunction
+++ b/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_custom_crafters:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down_check.mcfunction
+++ b/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_custom_crafters:relocate/replace_head

--- a/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/replace_head.mcfunction
+++ b/gm4_custom_crafters/data/gm4_custom_crafters/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_custom_crafters:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_custom_crafters:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-698910882,1355432644,-1608425408,-1046601502]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_custom_crafters:relocate/replace_head

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/east.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_disassemblers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_disassemblers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/north.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_disassemblers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/south.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_disassemblers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/west.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_disassemblers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down_check.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_disassemblers:relocate/replace_head

--- a/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/replace_head.mcfunction
+++ b/gm4_disassemblers/data/gm4_disassemblers/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_disassemblers:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_disassemblers:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;976088164,-1182119616,-1306607456,336514689]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_disassemblers:relocate/replace_head

--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/east.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_enchantment_extractors:relocate/place_down_check
+# @s = command block placed by gm4_enchantment_extractors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_enchantment_extractors:relocate/place_down_check
+# @s = command block placed by gm4_enchantment_extractors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/north.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_enchantment_extractors:relocate/place_down_check
+# @s = command block placed by gm4_enchantment_extractors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/south.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_enchantment_extractors:relocate/place_down_check
+# @s = command block placed by gm4_enchantment_extractors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/west.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_enchantment_extractors:relocate/place_down_check
+# @s = command block placed by gm4_enchantment_extractors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down_check.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_enchantment_extractors:relocate/replace_head

--- a/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/replace_head.mcfunction
+++ b/gm4_enchantment_extractors/data/gm4_enchantment_extractors/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_enchantment_extractors:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_enchantment_extractors:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-983517977,466373274,-1879558378,861584362]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_enchantment_extractors:relocate/replace_head

--- a/gm4_enchantment_extractors/pack.mcmeta
+++ b/gm4_enchantment_extractors/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "pack_format": 5,
+        "pack_format": 6,
         "description": "A Gamemode 4 Module"
     },
     "module_name": "Enchantment Extractors",

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/east.mcfunction
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_ender_hoppers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_ender_hoppers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/north.mcfunction
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_disassemblers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/south.mcfunction
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_ender_hoppers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/west.mcfunction
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_ender_hoppers:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down_check.mcfunction
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/east"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/west"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/south"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/north"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_ender_hoppers:relocate/replace_head

--- a/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/replace_head.mcfunction
+++ b/gm4_ender_hoppers/data/gm4_ender_hoppers/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_ender_hoppers:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/east"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/west"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/south"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/north"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_ender_hoppers:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-227409694,1209617203,-1656024256,-236766880]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_ender_hoppers:relocate/replace_head

--- a/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/east.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_liquid_tanks:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_liquid_tanks:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/north.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_liquid_tanks:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/south.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_liquid_tanks:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/west.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_liquid_tanks:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down_check.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/east"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/west"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/south"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/north"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_liquid_tanks:relocate/replace_head

--- a/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/replace_head.mcfunction
+++ b/gm4_liquid_tanks/data/gm4_liquid_tanks/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_liquid_tanks:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/east"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/west"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/south"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/north"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_liquid_tanks:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;870435466,-1787213241,-1355212297,-1164569835]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_liquid_tanks:relocate/replace_head

--- a/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/east.mcfunction
+++ b/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_master_crafting:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_master_crafting:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/north.mcfunction
+++ b/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_master_crafting:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/south.mcfunction
+++ b/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_master_crafting:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/west.mcfunction
+++ b/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_master_crafting:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down_check.mcfunction
+++ b/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_master_crafting:relocate/replace_head

--- a/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/replace_head.mcfunction
+++ b/gm4_master_crafting/data/gm4_master_crafting/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_master_crafting:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_master_crafting:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;1151454103,-965328753,-1345092288,1392238002]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_master_crafting:relocate/replace_head

--- a/gm4_relocators/data/gm4_relocators/advancements/place_relocator.json
+++ b/gm4_relocators/data/gm4_relocators/advancements/place_relocator.json
@@ -20,7 +20,7 @@
     }
   },
   "rewards": {
-    "function":"gm4_relocators:pick_up/replace_head"
+    "function":"gm4_relocators:pick_up/place_relocator"
   },
   "requirements": [
     [

--- a/gm4_relocators/data/gm4_relocators/functions/pick_up/delete_command_block.mcfunction
+++ b/gm4_relocators/data/gm4_relocators/functions/pick_up/delete_command_block.mcfunction
@@ -1,0 +1,8 @@
+# @s = command block deleting AEC
+# run from self and pick_up/find_machine
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 air replace command_block{CustomName:'{"text":"Relocator"}'}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_relocators:pick_up/delete_command_block

--- a/gm4_relocators/data/gm4_relocators/functions/pick_up/find_machine.mcfunction
+++ b/gm4_relocators/data/gm4_relocators/functions/pick_up/find_machine.mcfunction
@@ -9,6 +9,10 @@ execute unless score valid_machine gm4_rl_data matches 0 run advancement grant @
 
 execute if score valid_machine gm4_rl_data matches 0 run function gm4_relocators:pick_up/failed
 
-execute at @s run fill ~-6 ~-5 ~-6 ~6 ~7 ~6 air replace command_block{CustomName:'{"text":"Relocator"}'}
+#remove command block
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_delete"',Tags:["gm4_relocator_delete"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_delete,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_relocators:pick_up/delete_command_block
 
 tag @s remove gm4_rl_placed_relocator

--- a/gm4_relocators/data/gm4_relocators/functions/pick_up/place_relocator.mcfunction
+++ b/gm4_relocators/data/gm4_relocators/functions/pick_up/place_relocator.mcfunction
@@ -1,0 +1,11 @@
+# @s = player who placed a relocator player head
+# run from advancement "place_relocator"
+
+advancement revoke @s only gm4_relocators:place_relocator
+
+tag @s add gm4_rl_placed_relocator
+
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_relocators:pick_up/replace_head

--- a/gm4_relocators/data/gm4_relocators/functions/pick_up/replace_head.mcfunction
+++ b/gm4_relocators/data/gm4_relocators/functions/pick_up/replace_head.mcfunction
@@ -1,12 +1,12 @@
-# @s = player who placed a relocator player head
-# run from advancement "place_relocator"
+# @s = fill replacing AEC
+# run from self and pick_up/place_relocator
 
-advancement revoke @s only gm4_relocators:place_relocator
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~1 ~ ~ run function gm4_relocators:pick_up/find_machine"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~-1 ~ ~ run function gm4_relocators:pick_up/find_machine"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~ ~ ~1 run function gm4_relocators:pick_up/find_machine"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~ ~ ~-1 run function gm4_relocators:pick_up/find_machine"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~ ~-1 ~ run function gm4_relocators:pick_up/find_machine"} replace player_head{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
 
-tag @s add gm4_rl_placed_relocator
-
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~1 ~ ~ run function gm4_relocators:pick_up/find_machine"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~-1 ~ ~ run function gm4_relocators:pick_up/find_machine"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~ ~ ~1 run function gm4_relocators:pick_up/find_machine"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~ ~ ~-1 run function gm4_relocators:pick_up/find_machine"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,CustomName:'{"text":"Relocator"}',Command:"execute as @p[tag=gm4_rl_placed_relocator,distance=..10] positioned ~ ~-1 ~ run function gm4_relocators:pick_up/find_machine"} replace player_head{SkullOwner:{Id:[I;739224026,-1192800770,-2115274619,-970102126]}}
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_relocators:pick_up/replace_head

--- a/gm4_relocators/data/gm4_relocators/functions/place_down/place_block.mcfunction
+++ b/gm4_relocators/data/gm4_relocators/functions/place_down/place_block.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_block_compressors:relocate/place_down_check
+# @s = command block placed by gm4_block_compressors:relocate/replace_head
 
 execute at @p[tag=gm4_rl_placed_relocated_block,distance=..10] run loot spawn ~ ~.3 ~ loot gm4_relocators:relocator
 data merge entity @e[type=item,distance=..10,nbt={Age:0s},limit=1] {PickupDelay:0}

--- a/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/east.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_smelteries:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_smelteries:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/north.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_smelteries:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/south.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_smelteries:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/west.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_smelteries:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down_check.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_smelteries:relocate/place_down/east"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_smelteries:relocate/place_down/west"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_smelteries:relocate/place_down/south"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_smelteries:relocate/place_down/north"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_smelteries:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_smelteries:relocate/replace_head

--- a/gm4_smelteries/data/gm4_smelteries/functions/relocate/replace_head.mcfunction
+++ b/gm4_smelteries/data/gm4_smelteries/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_smelteries:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_smelteries:relocate/place_down/east"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_smelteries:relocate/place_down/west"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_smelteries:relocate/place_down/south"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_smelteries:relocate/place_down/north"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_smelteries:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-554836913,-358265892,-1824677954,1196488076]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_smelteries:relocate/replace_head

--- a/gm4_smelteries/pack.mcmeta
+++ b/gm4_smelteries/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "pack_format": 5,
+        "pack_format": 6,
         "description": "A Gamemode 4 Module"
     },
     "module_name": "Smelteries",

--- a/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/east.mcfunction
+++ b/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/east.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_tinkering_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/floor.mcfunction
+++ b/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/floor.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_tinkering_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/north.mcfunction
+++ b/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/north.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_tinkering_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/south.mcfunction
+++ b/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/south.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_tinkering_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/west.mcfunction
+++ b/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down/west.mcfunction
@@ -1,4 +1,4 @@
-# @s = command block placed by gm4_relocators:place_down/place_block
+# @s = command block placed by gm4_tinkering_compressors:relocate/replace_head
 
 function gm4_relocators:place_down/place_block
 

--- a/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down_check.mcfunction
+++ b/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/place_down_check.mcfunction
@@ -1,8 +1,8 @@
 # @s = player who placed a relocated block player head
 # run from #gm4_relocators:place_down
 
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=east]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=west]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=south]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=north]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
-fill ~-6 ~-5 ~-6 ~6 ~7 ~6 command_block[facing=down]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
+execute positioned ~ ~-5 ~ run kill @e[type=area_effect_cloud,tag=gm4_relocator_fill,dy=13]
+summon area_effect_cloud ~ ~-5 ~ {CustomName:'"gm4_relocator_fill"',Tags:["gm4_relocator_fill"],Particle:"block air"}
+scoreboard players set fill_success gm4_rl_data 0
+scoreboard players set fill_counter gm4_rl_data -5
+execute positioned ~ ~-5 ~ as @e[type=area_effect_cloud,tag=gm4_relocator_fill,limit=1,sort=nearest,distance=..0.01] at @s run function gm4_tinkering_compressors:relocate/replace_head

--- a/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/replace_head.mcfunction
+++ b/gm4_tinkering_compressors/data/gm4_tinkering_compressors/functions/relocate/replace_head.mcfunction
@@ -1,0 +1,12 @@
+# @s = fill replacing AEC
+# run from self and gm4_tinkering_compressors:place_down_check
+
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=east]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/west"} replace player_wall_head[facing=west]{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=west]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/east"} replace player_wall_head[facing=east]{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=south]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/north"} replace player_wall_head[facing=north]{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=north]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/south"} replace player_wall_head[facing=south]{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
+execute if score fill_success gm4_rl_data matches 0 store success score fill_success gm4_rl_data run fill ~-6 ~ ~-6 ~6 ~ ~6 command_block[facing=down]{auto:1,Command:"function gm4_tinkering_compressors:relocate/place_down/floor"} replace player_head{SkullOwner:{Id:[I;-376274969,744704688,-1218290593,1434816296]}}
+
+tp @s ~ ~1 ~
+scoreboard players add fill_counter gm4_rl_data 1
+execute if score fill_success gm4_rl_data matches 0 unless score fill_counter gm4_rl_data matches 8.. at @s run function gm4_tinkering_compressors:relocate/replace_head

--- a/gm4_tinkering_compressors/pack.mcmeta
+++ b/gm4_tinkering_compressors/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "pack_format": 5,
+        "pack_format": 6,
         "description": "A Gamemode 4 Module"
     },
     "module_name": "Tinkering Compressors",


### PR DESCRIPTION
- previously relocators would completely break when below y=5 or above y=248 due to the fill command not running if it includes blocks out of bounds