### PR TITLE
Split CMD of item and advancement

### DIFF
--- a/gm4_everstone/data/gm4/advancements/everstone.json
+++ b/gm4_everstone/data/gm4/advancements/everstone.json
@@ -2,7 +2,7 @@
   "display":{
     "icon":{
       "item":"firework_star",
-      "nbt":"{CustomModelData:2}"
+      "nbt":"{CustomModelData:3}"
     },
     "title":{
       "translate": "%1$s%3427655$s",


### PR DESCRIPTION
Ensuring Advancement Icons now have different CMD from the item/block they represent... Misode's orders :T